### PR TITLE
Add department of health's nutrient profiling model

### DIFF
--- a/ahl_scoping/analysis/nutrient_model_analysis/nutrient_model_analysis.py
+++ b/ahl_scoping/analysis/nutrient_model_analysis/nutrient_model_analysis.py
@@ -1,0 +1,46 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+from ahl_scoping.pipeline.nutrient_model import load_tesco_with_a_points
+import seaborn as sns
+
+# %%
+tesco_groceries = load_tesco_with_a_points()
+
+# %%
+# plot distribution of a_points
+sns.histplot(data=tesco_groceries, x="a_points", bins=26)
+
+# %%
+# plot distribution of a_points without -1 values (-1 is given when one of the nutrient values is NaN)
+sns.histplot(
+    data=tesco_groceries[tesco_groceries["a_points"] != -1], x="a_points", bins=26
+)
+
+# %%
+# plot energy unit against avg price, coloured by a points
+food_only = tesco_groceries[tesco_groceries["food_drink"] == "food"]
+sns.set(rc={"figure.figsize": (16, 12)})
+sns.scatterplot(data=food_only, x="avg_price", y="energyunit", hue="a_points")
+
+# %%
+# plot energy unit against a points
+food_only = tesco_groceries[tesco_groceries["food_drink"] == "food"]
+sns.set(rc={"figure.figsize": (16, 12)})
+sns.scatterplot(data=food_only, x="avg_price", y="a_points")
+
+# %%

--- a/ahl_scoping/pipeline/nutrient_model.py
+++ b/ahl_scoping/pipeline/nutrient_model.py
@@ -1,0 +1,50 @@
+"""Nutrient model which calculates a nutrient score
+as described:
+https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/216094/dh_123492.pdf
+Only the "A" points can be calculated at this stage.
+To calculate the "C" points, we need knowledge of the fruit,
+veg & nuts percentage. More information on the definitions of
+fruit, veg and nuts and how it is calculated can be found:
+https://webarchive.nationalarchives.gov.uk/20140716083912/http://multimedia.food.gov.uk/multimedia/pdfs/nutprofpguide.pdf
+"""
+import numpy as np
+from ahl_scoping.pipeline.tesco_preprocessing import preprocess_data
+
+
+def a_points(
+    row,
+    nutrients=["energyunit", "saturatesunit", "sugarsunit", "saltunit"],
+    cutoffs=[
+        [0, 335, 670, 1005, 1340, 1675, 2010, 2345, 2680, 3015, 3350, np.inf],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, np.inf],
+        [0, 4.5, 9, 13.5, 18, 22.5, 27, 31, 36, 40, 45, np.inf],
+        [0, 90, 180, 270, 360, 450, 540, 630, 720, 810, 900, np.inf],
+    ],
+):
+    """Return total number of A points from the
+    Department of Health's Nutrient Profiling technical
+    guidance (Jan 2011)
+
+    Args:
+        row: row of dataframe
+
+    Returns:
+        int: number of A points, returns -1 if any of the
+            nutrient values are NaNs
+    """
+    a_points = 0
+    for nutrient, cutoff in zip(nutrients, cutoffs):
+        if np.isnan(row[nutrient]):
+            return -1
+        for i in range(11):
+            if cutoff[i] < row[nutrient] <= cutoff[i + 1]:
+                a_points += i
+    return a_points
+
+
+def load_tesco_with_a_points(tesco_groceries_df=preprocess_data()):
+    """Returns tesco preprocessed data, with additional column
+    for A points from the nutrient profiling model"""
+    return tesco_groceries_df.assign(
+        a_points=tesco_groceries_df.apply(a_points, axis=1)
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ sh==1.14.2
 scikit-learn==0.24.2
 notebook==6.4.0
 wordcloud==1.8.1
+seaborn==0.11.1


### PR DESCRIPTION
Closes #8.

This pull request:
* Adds function to calculate nutrient score as calculated by the department of health's nutrient profiling model to `ahl_scoping/pipeline/nutrient_model.py`
* Adds jupytext notebook for analysing nutrient model with the tesco food dataset to `ahl_scoping/analysis/nutrient_model_analysis/nutrient_model_analysis.py`
* Updates requirements

The model is described [here](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/216094/dh_123492.pdf). Only the "A" points can be calculated at this stage.

To calculate the "C" points, we need knowledge of the fruit, veg & nuts percentage. More information on the definitions of fruit, veg and nuts and how it is calculated can be found [here](https://webarchive.nationalarchives.gov.uk/20140716083912/http://multimedia.food.gov.uk/multimedia/pdfs/nutprofpguide.pdf). 